### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
+dist: trusty
 
 jdk:
   - openjdk7
-  - oraclejdk7
   - oraclejdk8
 
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V


### PR DESCRIPTION
According to the doc, `oraclejdk7` is no more supported on any distribution :
> Oracle JDK 7 is not provided because it reached End of Life in April 2015.  
> See [here](https://docs.travis-ci.com/user/reference/trusty/#jvm-clojure-groovy-java-scala-images)

The dist `trusty` is the only distribution to support java 7 and java 8. So, it will fix your CI.

Should close #14 